### PR TITLE
Quoted String Support

### DIFF
--- a/Sources/AsciiPlistParser/PlistStringConvertible.swift
+++ b/Sources/AsciiPlistParser/PlistStringConvertible.swift
@@ -114,12 +114,22 @@ extension Object: PlistStringConvertible {
 
 extension StringValue: PlistStringConvertible {
     func string(_ depth: Int, isNewLineNeeded: Bool = true) -> String {
-        var result = "\(value)"
-        if let a = annotation {
-            result += " "
-            result += _annotation(a)
+        switch self {
+        case .raw(let value, let annotation):
+            var result = value
+            if let a = annotation {
+                result += " "
+                result += _annotation(a)
+            }
+            return result
+        case .quoted(let value, let annotation):
+            var result = "\"\(value)\""
+            if let a = annotation {
+                result += " "
+                result += _annotation(a)
+            }
+            return result
         }
-        return result
     }
 }
 

--- a/Sources/AsciiPlistParser/PlistStringConvertible.swift
+++ b/Sources/AsciiPlistParser/PlistStringConvertible.swift
@@ -21,17 +21,17 @@ extension Object: PlistStringConvertible {
             }
             guard let fstobj = fst.1 as? Object,
                 let sndobj = snd.1 as? Object else {
-                    return fst.0.nonQuotedValue < snd.0.nonQuotedValue
+                    return fst.0 < snd.0
             }
             if let isa1 = fstobj["isa"] as? StringValue,
                 let isa2 = sndobj["isa"] as? StringValue {
                 if isa1.value == isa2.value {
-                    return fst.0.nonQuotedValue < snd.0.nonQuotedValue
+                    return fst.0 < snd.0
                 } else {
                     return isa1.value < isa2.value
                 }
             }
-            if fst.0.nonQuotedValue > snd.0.nonQuotedValue {
+            if fst.0 > snd.0 {
                 return false
             }
             return true

--- a/Sources/AsciiPlistParser/Reader.swift
+++ b/Sources/AsciiPlistParser/Reader.swift
@@ -156,7 +156,7 @@ public class Reader {
         }
         eat(1)
         eatWhiteSpaceAndNewLine()
-        return StringValue(value: "\"\(string)\"", annotation: getAnnotation())
+        return .quoted(value: string, annotation: getAnnotation())
     }
 
     private func getStringValue() -> StringValue? {
@@ -178,9 +178,9 @@ public class Reader {
                     break
                 }
             }
-            return StringValue(value: value, annotation: a)
+            return .raw(value: value, annotation: a)
         } else {
-            return StringValue(value: string, annotation: nil)
+            return .raw(value: string, annotation: nil)
         }
     }
 

--- a/Sources/AsciiPlistParser/Sourcery.out.swift
+++ b/Sources/AsciiPlistParser/Sourcery.out.swift
@@ -30,14 +30,22 @@ public func == (lhs: ArrayValue, rhs: ArrayValue) -> Bool {
     guard lhs.value == rhs.value else { return false }
     return true
 }
-// MARK: - StringValue AutoEquatable
-extension StringValue: Equatable {} 
-public func == (lhs: StringValue, rhs: StringValue) -> Bool {
-    guard lhs.value == rhs.value else { return false }
-    guard compareOptionals(lhs: lhs.annotation, rhs: rhs.annotation, compare: ==) else { return false }
-    return true
-}
 
 // MARK: - AutoEquatable for Enums
+// MARK: - StringValue AutoEquatable
+extension StringValue: Equatable {}
+public func == (lhs: StringValue, rhs: StringValue) -> Bool {
+    switch (lhs, rhs) {
+    case (.quoted(let lhs), .quoted(let rhs)): 
+        if lhs.value != rhs.value { return false }
+        if lhs.annotation != rhs.annotation { return false }
+        return true
+    case (.raw(let lhs), .raw(let rhs)): 
+        if lhs.value != rhs.value { return false }
+        if lhs.annotation != rhs.annotation { return false }
+        return true
+    default: return false
+    }
+}
 
 // MARK: -

--- a/Tests/AsciiPlistParserTests/PlistStringConvertibleTests.swift
+++ b/Tests/AsciiPlistParserTests/PlistStringConvertibleTests.swift
@@ -34,10 +34,16 @@ class PlistStringConvertibleTests: XCTestCase {
     }
 
     func testStringValue() {
-        let value = StringValue(value: "Hello", annotation: "Hello.swift in Sources")
+        let value: StringValue = .raw(value: "Hello", annotation: "Hello.swift in Sources")
         let expected = "Hello /* Hello.swift in Sources */"
         XCTAssertEqual(value.string(0), expected)
         XCTAssertEqual(StringValue(value: "Hello", annotation: nil).string(0), "Hello")
+    }
+
+    func testQuotedStringValue() {
+        let value: StringValue = .quoted(value: "Hello", annotation: "Hello.swift in Sources")
+        let expected = "\"Hello\" /* Hello.swift in Sources */"
+        XCTAssertEqual(value.string(0), expected)
     }
 
     func testArrayStringValue() {

--- a/Tests/AsciiPlistParserTests/PlistStringConvertibleTests.swift
+++ b/Tests/AsciiPlistParserTests/PlistStringConvertibleTests.swift
@@ -27,13 +27,13 @@ class PlistStringConvertibleTests: XCTestCase {
             "B1231",
             "B1233",
             "B1234",
-            "\"C1233\"",
+            "C1233",
             "A12345",
             "A12346",
         ])
     }
 
-    func testStringStringValue() {
+    func testStringValue() {
         let value = StringValue(value: "Hello", annotation: "Hello.swift in Sources")
         let expected = "Hello /* Hello.swift in Sources */"
         XCTAssertEqual(value.string(0), expected)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,7 +6,7 @@ import XCTest
 extension ObjectTests {
   static var allTests: [(String, (ObjectTests) -> () throws -> Void)] = [
     ("testObjectEquatableAgainstStringValue", testObjectEquatableAgainstStringValue),
-    ("testObjectEquatableAgainstOtherTypes", testObjectEquatableAgainstOtherTypes),
+    ("testDictionary", testDictionary),
   ]
 }
 extension PlistStringConvertibleTests {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -13,7 +13,7 @@ extension PlistStringConvertibleTests {
   static var allTests: [(String, (PlistStringConvertibleTests) -> () throws -> Void)] = [
     ("testSorted", testSorted),
     ("testSorted002", testSorted002),
-    ("testStringStringValue", testStringStringValue),
+    ("testStringValue", testStringValue),
     ("testArrayStringValue", testArrayStringValue),
     ("testObject", testObject),
     ("testPbxprojCompatibility", testPbxprojCompatibility),


### PR DESCRIPTION
Sometimes pbxproj has quoted "key" or "value".

example:
```
    "CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
```

Replaced existing `struct StringValue` with `enum StringValue` with `raw` and `quoted` cases.

Reader parses fields to this enum, and writer (PlistStringConvertible conformance) writes back exactly same thing which Reader parsed.